### PR TITLE
Add Cloudflare OAuth sign-in (public client + PKCE)

### DIFF
--- a/macflare/Info.plist
+++ b/macflare/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CloudflareClientID</key>
+	<string>$(CLOUDFLARE_CLIENT_ID)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/macflare/Info.plist
+++ b/macflare/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.example.macflare.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>macflare</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/macflare/Model/AuthState.swift
+++ b/macflare/Model/AuthState.swift
@@ -1,0 +1,32 @@
+//
+//  AuthState.swift
+//  macflare
+//
+//  High-level authentication state that drives root navigation.
+//
+
+import Foundation
+
+/// High-level authentication state used to switch the app's root view.
+enum AuthState: Equatable {
+    case signedOut
+    case authenticating
+    case signedIn
+    /// Sign-in failed; the associated value is a user-presentable message.
+    case failed(String)
+
+    var isSignedIn: Bool {
+        if case .signedIn = self { return true }
+        return false
+    }
+
+    var isAuthenticating: Bool {
+        if case .authenticating = self { return true }
+        return false
+    }
+
+    var failureMessage: String? {
+        if case .failed(let message) = self { return message }
+        return nil
+    }
+}

--- a/macflare/Model/AuthToken.swift
+++ b/macflare/Model/AuthToken.swift
@@ -1,0 +1,78 @@
+//
+//  AuthToken.swift
+//  macflare
+//
+//  OAuth token set returned by Cloudflare's token endpoint.
+//
+
+import Foundation
+
+/// An OAuth token set returned by Cloudflare's token endpoint.
+///
+/// Conforms to `Codable` so it can be parsed from the token response and
+/// persisted to the Keychain, and to `Hashable` per project model conventions.
+struct AuthToken: Codable, Hashable {
+    let accessToken: String
+    let refreshToken: String?
+    let tokenType: String
+    let scope: String?
+    /// Absolute expiry time, derived from `expires_in` at decode time.
+    let expiresAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+        case scope
+        case expiresIn = "expires_in"
+        case expiresAt
+    }
+
+    init(
+        accessToken: String,
+        refreshToken: String?,
+        tokenType: String,
+        scope: String?,
+        expiresAt: Date?
+    ) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.tokenType = tokenType
+        self.scope = scope
+        self.expiresAt = expiresAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        tokenType = try container.decodeIfPresent(String.self, forKey: .tokenType) ?? "Bearer"
+        scope = try container.decodeIfPresent(String.self, forKey: .scope)
+
+        // Prefer a precomputed absolute expiry (when re-decoding from the
+        // Keychain), otherwise derive it from the relative `expires_in` seconds
+        // returned by the token endpoint.
+        if let absolute = try container.decodeIfPresent(Date.self, forKey: .expiresAt) {
+            expiresAt = absolute
+        } else if let expiresIn = try container.decodeIfPresent(Double.self, forKey: .expiresIn) {
+            expiresAt = Date().addingTimeInterval(expiresIn)
+        } else {
+            expiresAt = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(accessToken, forKey: .accessToken)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+        try container.encode(tokenType, forKey: .tokenType)
+        try container.encodeIfPresent(scope, forKey: .scope)
+        try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
+    }
+
+    /// Whether the access token is expired (or about to expire within `leeway`).
+    func isExpired(leeway: TimeInterval = 60) -> Bool {
+        guard let expiresAt else { return false }
+        return Date().addingTimeInterval(leeway) >= expiresAt
+    }
+}

--- a/macflare/Services/API/CloudflareAPIClient.swift
+++ b/macflare/Services/API/CloudflareAPIClient.swift
@@ -1,0 +1,43 @@
+//
+//  CloudflareAPIClient.swift
+//  macflare
+//
+//  Thin REST client that injects the OAuth bearer token.
+//
+
+import Foundation
+
+/// Thin client for the Cloudflare REST API that injects the OAuth bearer token.
+///
+/// The token is supplied lazily via ``tokenProvider`` so the caller (the auth
+/// manager) can transparently refresh an expired access token before each call.
+struct CloudflareAPIClient {
+    /// Returns a currently-valid access token, refreshing if necessary.
+    let tokenProvider: () async throws -> String
+    var session: URLSession = .shared
+
+    /// Verifies the current token by listing accounts. Returns the account
+    /// identifiers on success; throws ``OAuthError/server(_:)`` on failure.
+    @discardableResult
+    func verifyToken() async throws -> [String] {
+        let url = CloudflareOAuthConfig.apiBaseURL.appendingPathComponent("accounts")
+        var request = URLRequest(url: url)
+        let token = try await tokenProvider()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw OAuthError.server("Invalid response from Cloudflare.")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw OAuthError.server("Cloudflare API returned status \(http.statusCode).")
+        }
+        return try JSONDecoder().decode(AccountsResponse.self, from: data).result.map(\.id)
+    }
+}
+
+private struct AccountsResponse: Decodable {
+    struct Account: Decodable { let id: String }
+    let result: [Account]
+}

--- a/macflare/Services/Keychain/KeychainStore.swift
+++ b/macflare/Services/Keychain/KeychainStore.swift
@@ -1,0 +1,90 @@
+//
+//  KeychainStore.swift
+//  macflare
+//
+//  Secure persistence for the OAuth token using the macOS Keychain.
+//
+
+import Foundation
+import Security
+
+/// Minimal, secure persistence for the OAuth token using the macOS Keychain.
+///
+/// Tokens are sensitive, so they are never written to `UserDefaults` or logs. A
+/// single generic-password item holds the JSON-encoded ``AuthToken``.
+struct KeychainStore {
+    enum KeychainError: Error, Equatable {
+        case unexpectedStatus(OSStatus)
+    }
+
+    let service: String
+    let account: String
+
+    init(service: String = "com.macflare.oauth", account: String = "cloudflare-token") {
+        self.service = service
+        self.account = account
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    /// Saves (or replaces) the token. The item is accessible only after first
+    /// unlock and never syncs to other devices.
+    func save(_ token: AuthToken) throws {
+        let data = try JSONEncoder().encode(token)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+
+        let status = SecItemCopyMatching(baseQuery as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            let updateStatus = SecItemUpdate(baseQuery as CFDictionary, attributes as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(updateStatus)
+            }
+        case errSecItemNotFound:
+            var addQuery = baseQuery
+            addQuery.merge(attributes) { _, new in new }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(addStatus)
+            }
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Loads the persisted token, or `nil` if none is stored.
+    func load() throws -> AuthToken? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data else { return nil }
+            return try JSONDecoder().decode(AuthToken.self, from: data)
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Removes the persisted token (used on sign-out).
+    func delete() throws {
+        let status = SecItemDelete(baseQuery as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/macflare/Services/OAuth/CloudflareAuthManager.swift
+++ b/macflare/Services/OAuth/CloudflareAuthManager.swift
@@ -1,0 +1,209 @@
+//
+//  CloudflareAuthManager.swift
+//  macflare
+//
+//  Coordinates the full Cloudflare OAuth lifecycle.
+//
+
+import Foundation
+import Observation
+
+/// Coordinates the full Cloudflare OAuth lifecycle: launching the consent flow,
+/// exchanging the authorization code (PKCE), persisting tokens to the Keychain,
+/// refreshing them, and signing out.
+@MainActor
+@Observable
+final class CloudflareAuthManager {
+    private(set) var state: AuthState = .signedOut
+
+    @ObservationIgnored private let authorizer: OAuthRedirectAuthorizing
+    @ObservationIgnored private let keychain: KeychainStore
+    @ObservationIgnored private let urlSession: URLSession
+    @ObservationIgnored private var token: AuthToken?
+
+    init(
+        authorizer: OAuthRedirectAuthorizing? = nil,
+        keychain: KeychainStore = KeychainStore(),
+        urlSession: URLSession = .shared
+    ) {
+        self.authorizer = authorizer ?? WebAuthenticationSessionAuthorizer()
+        self.keychain = keychain
+        self.urlSession = urlSession
+    }
+
+    /// Restores any previously persisted session. Call once at launch.
+    func restore() {
+        if let stored = try? keychain.load() {
+            token = stored
+            state = .signedIn
+        }
+    }
+
+    /// Builds an API client whose bearer token is always valid (refreshed first).
+    func makeAPIClient() -> CloudflareAPIClient {
+        CloudflareAPIClient(
+            tokenProvider: { [weak self] in
+                guard let self else { throw OAuthError.notConfigured }
+                return try await self.validAccessToken()
+            },
+            session: urlSession
+        )
+    }
+
+    /// Runs the Authorization Code + PKCE flow end to end.
+    func signIn() async {
+        guard CloudflareOAuthConfig.isConfigured else {
+            state = .failed(OAuthError.notConfigured.localizedDescription)
+            return
+        }
+        state = .authenticating
+        do {
+            let pkce = PKCE()
+            let expectedState = PKCE.makeState()
+            let authURL = makeAuthorizationURL(pkce: pkce, state: expectedState)
+
+            let callback = try await authorizer.authorize(
+                url: authURL,
+                callbackScheme: CloudflareOAuthConfig.callbackURLScheme
+            )
+            let code = try authorizationCode(from: callback, expectedState: expectedState)
+            let newToken = try await exchange(code: code, verifier: pkce.codeVerifier)
+
+            try keychain.save(newToken)
+            token = newToken
+            state = .signedIn
+        } catch {
+            let message = (error as? OAuthError)?.localizedDescription ?? error.localizedDescription
+            state = .failed(message)
+        }
+    }
+
+    /// Clears the session and persisted token.
+    func signOut() {
+        try? keychain.delete()
+        token = nil
+        state = .signedOut
+    }
+
+    // MARK: - Token handling
+
+    /// Returns a non-expired access token, refreshing it if necessary.
+    private func validAccessToken() async throws -> String {
+        guard let current = token else { throw OAuthError.notConfigured }
+        if current.isExpired(), let refreshToken = current.refreshToken {
+            let refreshed = try await refresh(using: refreshToken)
+            try keychain.save(refreshed)
+            token = refreshed
+            return refreshed.accessToken
+        }
+        return current.accessToken
+    }
+
+    // MARK: - Request building
+
+    private func makeAuthorizationURL(pkce: PKCE, state: String) -> URL {
+        var components = URLComponents(
+            url: CloudflareOAuthConfig.authorizationEndpoint,
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: CloudflareOAuthConfig.clientID),
+            URLQueryItem(name: "redirect_uri", value: CloudflareOAuthConfig.redirectURI),
+            URLQueryItem(name: "scope", value: CloudflareOAuthConfig.scopeString),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: pkce.codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: pkce.method),
+        ]
+        return components.url!
+    }
+
+    private func authorizationCode(from callbackURL: URL, expectedState: String) throws -> String {
+        guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              let items = components.queryItems else {
+            throw OAuthError.missingAuthorizationCode
+        }
+        if let serverError = items.first(where: { $0.name == "error" })?.value {
+            let description = items.first(where: { $0.name == "error_description" })?.value
+            throw OAuthError.server(description ?? serverError)
+        }
+        guard items.first(where: { $0.name == "state" })?.value == expectedState else {
+            throw OAuthError.stateMismatch
+        }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw OAuthError.missingAuthorizationCode
+        }
+        return code
+    }
+
+    private func exchange(code: String, verifier: String) async throws -> AuthToken {
+        try await postToken(parameters: [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": CloudflareOAuthConfig.redirectURI,
+            "client_id": CloudflareOAuthConfig.clientID,
+            "code_verifier": verifier,
+        ])
+    }
+
+    private func refresh(using refreshToken: String) async throws -> AuthToken {
+        let refreshed = try await postToken(parameters: [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": CloudflareOAuthConfig.clientID,
+        ])
+        // Cloudflare may omit a rotated refresh token; keep the existing one.
+        guard refreshed.refreshToken == nil else { return refreshed }
+        return AuthToken(
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshToken,
+            tokenType: refreshed.tokenType,
+            scope: refreshed.scope,
+            expiresAt: refreshed.expiresAt
+        )
+    }
+
+    private func postToken(parameters: [String: String]) async throws -> AuthToken {
+        var request = URLRequest(url: CloudflareOAuthConfig.tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = Self.formURLEncode(parameters).data(using: .utf8)
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw OAuthError.server("Invalid response from Cloudflare token endpoint.")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let message = Self.errorMessage(from: data)
+                ?? "Token request failed (status \(http.statusCode))."
+            throw OAuthError.server(message)
+        }
+        return try JSONDecoder().decode(AuthToken.self, from: data)
+    }
+
+    private static func formURLEncode(_ parameters: [String: String]) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return parameters
+            .map { key, value in
+                let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+                let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+                return "\(encodedKey)=\(encodedValue)"
+            }
+            .joined(separator: "&")
+    }
+
+    private static func errorMessage(from data: Data) -> String? {
+        struct TokenError: Decodable {
+            let error: String?
+            let errorDescription: String?
+            enum CodingKeys: String, CodingKey {
+                case error
+                case errorDescription = "error_description"
+            }
+        }
+        guard let decoded = try? JSONDecoder().decode(TokenError.self, from: data) else { return nil }
+        return decoded.errorDescription ?? decoded.error
+    }
+}

--- a/macflare/Services/OAuth/CloudflareOAuthConfig.swift
+++ b/macflare/Services/OAuth/CloudflareOAuthConfig.swift
@@ -1,0 +1,54 @@
+//
+//  CloudflareOAuthConfig.swift
+//  macflare
+//
+//  Static configuration for Cloudflare's public OAuth client flow.
+//
+
+import Foundation
+
+/// Configuration for authenticating with Cloudflare as a *public* OAuth client.
+///
+/// As of Cloudflare's 2026-06-03 "public OAuth clients" release, native apps can
+/// use the OAuth 2.0 Authorization Code flow with PKCE and **no client secret**,
+/// which is exactly what a distributed desktop app like MacFlare needs.
+enum CloudflareOAuthConfig {
+    /// The client ID issued when registering a public OAuth client in the
+    /// Cloudflare dashboard. Public clients have no secret.
+    ///
+    /// - Important: Populate this with the real client ID before shipping. It is
+    ///   intentionally left empty so an unconfigured build fails loudly (via
+    ///   ``isConfigured``) rather than starting a broken sign-in.
+    static let clientID = ""
+
+    /// Endpoint the user is sent to in order to grant consent.
+    static let authorizationEndpoint = URL(string: "https://dash.cloudflare.com/oauth2/auth")!
+
+    /// Endpoint used to exchange the authorization code (and later refresh
+    /// tokens) for access tokens.
+    static let tokenEndpoint = URL(string: "https://dash.cloudflare.com/oauth2/token")!
+
+    /// Base URL for the Cloudflare REST API, used once authenticated.
+    static let apiBaseURL = URL(string: "https://api.cloudflare.com/client/v4")!
+
+    /// Custom URL scheme registered in `Info.plist` for the OAuth redirect.
+    static let callbackURLScheme = "macflare"
+
+    /// Redirect URI registered with the OAuth client. The custom scheme lets
+    /// `ASWebAuthenticationSession` intercept the callback automatically.
+    static let redirectURI = "\(callbackURLScheme)://oauth-callback"
+
+    /// Requested scopes. `offline_access` is required to receive a refresh token.
+    static let scopes = [
+        "account:read",
+        "user:read",
+        "zone:read",
+        "offline_access",
+    ]
+
+    /// Space-delimited scope string for the authorization request.
+    static var scopeString: String { scopes.joined(separator: " ") }
+
+    /// Whether a usable client ID has been configured.
+    static var isConfigured: Bool { !clientID.isEmpty }
+}

--- a/macflare/Services/OAuth/CloudflareOAuthConfig.swift
+++ b/macflare/Services/OAuth/CloudflareOAuthConfig.swift
@@ -14,12 +14,23 @@ import Foundation
 /// which is exactly what a distributed desktop app like MacFlare needs.
 enum CloudflareOAuthConfig {
     /// The client ID issued when registering a public OAuth client in the
-    /// Cloudflare dashboard. Public clients have no secret.
+    /// Cloudflare dashboard. Public clients have no secret, so this is not
+    /// sensitive.
     ///
-    /// - Important: Populate this with the real client ID before shipping. It is
-    ///   intentionally left empty so an unconfigured build fails loudly (via
-    ///   ``isConfigured``) rather than starting a broken sign-in.
-    static let clientID = ""
+    /// Loaded from the `CloudflareClientID` Info.plist key, which is wired to the
+    /// `CLOUDFLARE_CLIENT_ID` build setting so it can be supplied via an xcconfig
+    /// or CI without editing source. An empty/unset value means "not configured"
+    /// (see ``isConfigured``), so an unconfigured build fails loudly rather than
+    /// starting a broken sign-in.
+    static let clientID: String = {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: "CloudflareClientID") as? String else {
+            return ""
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Guard against an unexpanded build-setting placeholder (e.g. when
+        // CLOUDFLARE_CLIENT_ID is undefined and not substituted).
+        return trimmed.hasPrefix("$(") ? "" : trimmed
+    }()
 
     /// Endpoint the user is sent to in order to grant consent.
     static let authorizationEndpoint = URL(string: "https://dash.cloudflare.com/oauth2/auth")!

--- a/macflare/Services/OAuth/OAuthWebSession.swift
+++ b/macflare/Services/OAuth/OAuthWebSession.swift
@@ -1,0 +1,106 @@
+//
+//  OAuthWebSession.swift
+//  macflare
+//
+//  Browser round-trip that returns the OAuth redirect URL.
+//
+
+import AuthenticationServices
+import Foundation
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// Errors surfaced by the OAuth flow.
+enum OAuthError: Error, LocalizedError, Equatable {
+    case notConfigured
+    case userCancelled
+    case missingCallbackURL
+    case stateMismatch
+    case missingAuthorizationCode
+    case server(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Cloudflare OAuth client is not configured."
+        case .userCancelled:
+            return "Sign in was cancelled."
+        case .missingCallbackURL:
+            return "No callback was received from Cloudflare."
+        case .stateMismatch:
+            return "The sign-in response failed a security check. Please try again."
+        case .missingAuthorizationCode:
+            return "Cloudflare did not return an authorization code."
+        case .server(let message):
+            return message
+        }
+    }
+}
+
+/// Abstraction over the browser round-trip that returns the OAuth redirect URL.
+///
+/// Keeping this behind a protocol lets the redirect mechanism — custom-scheme
+/// `ASWebAuthenticationSession` today, a loopback listener if Cloudflare's public
+/// client registration ever requires it — change without touching flow logic.
+@MainActor
+protocol OAuthRedirectAuthorizing {
+    /// Opens `url`, waits for the redirect to the registered callback scheme, and
+    /// returns the full callback URL (including `code` and `state`).
+    func authorize(url: URL, callbackScheme: String) async throws -> URL
+}
+
+/// `ASWebAuthenticationSession`-backed implementation. Presents Apple's secure,
+/// ephemeral auth web view and captures the custom-scheme redirect.
+@MainActor
+final class WebAuthenticationSessionAuthorizer: NSObject, OAuthRedirectAuthorizing {
+    /// Held for the lifetime of the flow; `ASWebAuthenticationSession` is
+    /// cancelled if its strong reference is dropped before completion.
+    private var session: ASWebAuthenticationSession?
+
+    func authorize(url: URL, callbackScheme: String) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: callbackScheme
+            ) { [weak self] callbackURL, error in
+                self?.session = nil
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == ASWebAuthenticationSessionErrorDomain,
+                       nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        continuation.resume(throwing: OAuthError.userCancelled)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                    return
+                }
+                guard let callbackURL else {
+                    continuation.resume(throwing: OAuthError.missingCallbackURL)
+                    return
+                }
+                continuation.resume(returning: callbackURL)
+            }
+
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            self.session = session
+
+            if !session.start() {
+                self.session = nil
+                continuation.resume(throwing: OAuthError.missingCallbackURL)
+            }
+        }
+    }
+}
+
+extension WebAuthenticationSessionAuthorizer: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        #if os(macOS)
+        return NSApplication.shared.windows.first ?? ASPresentationAnchor()
+        #else
+        return ASPresentationAnchor()
+        #endif
+    }
+}

--- a/macflare/Services/OAuth/PKCE.swift
+++ b/macflare/Services/OAuth/PKCE.swift
@@ -1,0 +1,58 @@
+//
+//  PKCE.swift
+//  macflare
+//
+//  Proof Key for Code Exchange (RFC 7636) helpers for the OAuth flow.
+//
+
+import CryptoKit
+import Foundation
+
+/// PKCE parameters (RFC 7636) for a single OAuth authorization.
+///
+/// Public clients cannot hold a client secret, so PKCE binds the authorization
+/// request to the token exchange: we send a hashed ``codeChallenge`` up front and
+/// prove possession of the original ``codeVerifier`` when redeeming the code.
+struct PKCE: Equatable {
+    let codeVerifier: String
+    let codeChallenge: String
+    let method = "S256"
+
+    init() {
+        let verifier = PKCE.makeCodeVerifier()
+        self.codeVerifier = verifier
+        self.codeChallenge = PKCE.makeChallenge(for: verifier)
+    }
+
+    /// Generates a high-entropy, URL-safe code verifier (RFC 7636 §4.1).
+    static func makeCodeVerifier() -> String {
+        randomBase64URLString(byteCount: 32)
+    }
+
+    /// Computes the S256 challenge: BASE64URL(SHA256(ASCII(verifier))).
+    static func makeChallenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return Data(digest).base64URLEncodedString()
+    }
+
+    /// A random, URL-safe `state` value to defend against CSRF on the callback.
+    static func makeState() -> String {
+        randomBase64URLString(byteCount: 16)
+    }
+
+    private static func randomBase64URLString(byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncodedString()
+    }
+}
+
+extension Data {
+    /// Base64URL encoding without padding (RFC 4648 §5), as required by PKCE.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/macflare/View/RootView.swift
+++ b/macflare/View/RootView.swift
@@ -1,0 +1,26 @@
+//
+//  RootView.swift
+//  macflare
+//
+//  Switches between the welcome/login screen and the main content based on
+//  authentication state.
+//
+
+import SwiftUI
+
+struct RootView: View {
+    @Environment(CloudflareAuthManager.self) private var authManager
+
+    var body: some View {
+        if authManager.state.isSignedIn {
+            ContentView()
+        } else {
+            WelcomeView()
+        }
+    }
+}
+
+#Preview {
+    RootView()
+        .environment(CloudflareAuthManager())
+}

--- a/macflare/View/WelcomeView.swift
+++ b/macflare/View/WelcomeView.swift
@@ -21,7 +21,8 @@ struct VisualEffectView: NSViewRepresentable {
 
 struct WelcomeView: View {
     @Inject.ObserveInjection var inject
-    
+    @Environment(CloudflareAuthManager.self) private var authManager
+
     var body: some View {
         VStack(spacing: 40) {
             Spacer()
@@ -51,8 +52,23 @@ struct WelcomeView: View {
             
             // Action Buttons
             VStack(spacing: 16) {
-                Button("Login with Cloudflare") {
-                    
+                Button {
+                    Task { await authManager.signIn() }
+                } label: {
+                    if authManager.state.isAuthenticating {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Login with Cloudflare")
+                    }
+                }
+                .disabled(authManager.state.isAuthenticating)
+
+                if let message = authManager.state.failureMessage {
+                    Text(message)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
                 }
             }
             .padding(.horizontal, 20)
@@ -75,4 +91,5 @@ struct WelcomeView: View {
 
 #Preview {
     WelcomeView()
+        .environment(CloudflareAuthManager())
 }

--- a/macflare/macflareApp.swift
+++ b/macflare/macflareApp.swift
@@ -12,6 +12,8 @@ import AppKit
 
 @main
 struct MacflareApp: App {
+    @State private var authManager = CloudflareAuthManager()
+
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Item.self,
@@ -27,9 +29,11 @@ struct MacflareApp: App {
 
     var body: some Scene {
         WindowGroup {
-            WelcomeView()
+            RootView()
+                .environment(authManager)
                 .background(Color.clear)
                 .onAppear {
+                    authManager.restore()
                     configureWindow()
                 }
         }

--- a/macflareTests/OAuthTests.swift
+++ b/macflareTests/OAuthTests.swift
@@ -1,0 +1,108 @@
+//
+//  OAuthTests.swift
+//  macflareTests
+//
+//  Tests for the Cloudflare OAuth (public client + PKCE) building blocks.
+//
+
+import Foundation
+import Testing
+@testable import macflare
+
+struct OAuthTests {
+
+    // MARK: - PKCE
+
+    /// Known-answer test from RFC 7636 Appendix B.
+    @Test func pkceChallengeMatchesRFC7636Vector() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        let challenge = PKCE.makeChallenge(for: verifier)
+        #expect(challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test func pkceGeneratesURLSafeChallenge() {
+        let pkce = PKCE()
+        #expect(!pkce.codeVerifier.isEmpty)
+        #expect(pkce.method == "S256")
+        #expect(!pkce.codeChallenge.contains("="))
+        #expect(!pkce.codeChallenge.contains("+"))
+        #expect(!pkce.codeChallenge.contains("/"))
+        // The challenge must be reproducible from its verifier.
+        #expect(PKCE.makeChallenge(for: pkce.codeVerifier) == pkce.codeChallenge)
+    }
+
+    @Test func pkceVerifiersAreUnique() {
+        #expect(PKCE().codeVerifier != PKCE().codeVerifier)
+    }
+
+    // MARK: - AuthToken
+
+    @Test func authTokenDecodesExpiresIntoAbsoluteDate() throws {
+        let json = Data("""
+        {"access_token":"abc","refresh_token":"def","token_type":"bearer","scope":"account:read","expires_in":3600}
+        """.utf8)
+        let token = try JSONDecoder().decode(AuthToken.self, from: json)
+        #expect(token.accessToken == "abc")
+        #expect(token.refreshToken == "def")
+        #expect(token.tokenType == "bearer")
+        #expect(token.expiresAt != nil)
+        #expect(!token.isExpired())
+    }
+
+    @Test func authTokenDefaultsTokenTypeWhenMissing() throws {
+        let json = Data(#"{"access_token":"abc"}"#.utf8)
+        let token = try JSONDecoder().decode(AuthToken.self, from: json)
+        #expect(token.tokenType == "Bearer")
+        #expect(token.refreshToken == nil)
+        #expect(token.expiresAt == nil)
+        // A token with no expiry is treated as non-expiring.
+        #expect(!token.isExpired())
+    }
+
+    @Test func authTokenRoundTripsThroughCoding() throws {
+        let original = AuthToken(
+            accessToken: "a",
+            refreshToken: "r",
+            tokenType: "Bearer",
+            scope: "account:read",
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AuthToken.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func expiredTokenIsDetected() {
+        let token = AuthToken(
+            accessToken: "a",
+            refreshToken: nil,
+            tokenType: "Bearer",
+            scope: nil,
+            expiresAt: Date().addingTimeInterval(-10)
+        )
+        #expect(token.isExpired())
+    }
+
+    // MARK: - Keychain
+
+    @Test func keychainStoreRoundTripsToken() throws {
+        // Use a unique account so the test never collides with a real session.
+        let store = KeychainStore(service: "com.macflare.tests", account: UUID().uuidString)
+        defer { try? store.delete() }
+
+        let token = AuthToken(
+            accessToken: "access",
+            refreshToken: "refresh",
+            tokenType: "Bearer",
+            scope: "account:read",
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        try store.save(token)
+
+        let loaded = try store.load()
+        #expect(loaded == token)
+
+        try store.delete()
+        #expect(try store.load() == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Cloudflare's [2026-06-03 "public OAuth clients" release](https://developers.cloudflare.com/changelog/post/2026-06-03-public-oauth-clients/) is the missing piece that makes a real "Sign in with Cloudflare" flow possible for MacFlare. Public OAuth clients use the **Authorization Code flow with PKCE** and require **no client secret** — exactly what a distributed native macOS app needs (a shipped app can't safely embed a confidential secret).

Previously the `WelcomeView` "Login with Cloudflare" button was an empty closure with no auth, no API client, and no token storage. This PR implements the end-to-end flow.

## What's included

- **PKCE** (`PKCE.swift`) — URL-safe code verifier, S256 challenge, and a CSRF `state` nonce.
- **Models** — `AuthToken` (Codable/Hashable; derives absolute expiry from `expires_in`) and `AuthState` for root navigation.
- **Secure storage** (`KeychainStore.swift`) — token persisted in the macOS Keychain (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`); never in UserDefaults or logs.
- **Flow orchestration** (`CloudflareAuthManager.swift`) — builds the authorize URL, runs the browser round-trip, validates `state`, exchanges the code with the PKCE verifier, persists the token, and transparently refreshes it.
- **Redirect capture** (`OAuthWebSession.swift`) — `ASWebAuthenticationSession` with the `macflare://oauth-callback` custom scheme, behind an `OAuthRedirectAuthorizing` protocol so a loopback (127.0.0.1) listener can be dropped in if registration requires it.
- **API client** (`CloudflareAPIClient.swift`) — attaches the bearer token and verifies it via `GET /accounts`.
- **UI wiring** — `RootView` gates `WelcomeView` vs `ContentView` on auth state; the login button starts the flow with in-progress and error states; `macflare://` scheme registered in `Info.plist`.
- **Tests** (`OAuthTests.swift`) — PKCE RFC 7636 known-answer vector, token decoding/round-trip, and a Keychain round-trip (Swift Testing, matching the existing test style).

## Required follow-up before sign-in works

1. **Register a public OAuth client** in the Cloudflare dashboard and set `CloudflareOAuthConfig.clientID` (left blank intentionally so an unconfigured build fails loudly via `isConfigured`). Confirm the chosen **scopes** and that the **redirect URI** type (custom scheme vs loopback) is accepted.
2. **Confirm endpoint paths** (`/oauth2/auth`, `/oauth2/token`) and the exact token request shape against the live Cloudflare docs — these were gathered via web search because `developers.cloudflare.com` blocks automated fetches from this environment.

## Verification

This was developed in a Linux container with no Xcode/Swift toolchain, so it has **not been compiled**. Please build and run on macOS:

- `xcodebuild -scheme macflare -destination 'platform=macOS' build`
- `xcodebuild -scheme macflare -destination 'platform=macOS' test` (PKCE + token + Keychain tests)
- Manual: set a real `clientID`, click "Login with Cloudflare", complete consent, confirm the token is stored, the root view flips to `ContentView`, `verifyToken()` returns accounts, the session survives relaunch, and `signOut()` clears it.

New `.swift` files are picked up automatically via the project's Xcode 16 synchronized folders (`PBXFileSystemSynchronizedRootGroup`), so no `project.pbxproj` changes were needed.

https://claude.ai/code/session_01RhD6xc3LLc1s7Jvn7vZUbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhD6xc3LLc1s7Jvn7vZUbf)_